### PR TITLE
JCLOUDS-457: Added deleteArchive and uploadArchive operations.

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/GlacierAsyncClient.java
+++ b/glacier/src/main/java/org/jclouds/glacier/GlacierAsyncClient.java
@@ -24,21 +24,29 @@ import java.net.URI;
 import javax.inject.Named;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 import org.jclouds.Fallbacks.NullOnNotFoundOr404;
 import org.jclouds.blobstore.attr.BlobScope;
+import org.jclouds.glacier.binders.BindDescriptionToHeaders;
+import org.jclouds.glacier.binders.BindHashesToHeaders;
 import org.jclouds.glacier.domain.PaginatedVaultCollection;
 import org.jclouds.glacier.domain.VaultMetadata;
 import org.jclouds.glacier.fallbacks.FalseOnIllegalArgumentException;
 import org.jclouds.glacier.filters.RequestAuthorizeSignature;
+import org.jclouds.glacier.functions.ParseArchiveIdHeader;
 import org.jclouds.glacier.functions.ParseVaultMetadataFromHttpContent;
 import org.jclouds.glacier.functions.ParseVaultMetadataListFromHttpContent;
 import org.jclouds.glacier.options.PaginationOptions;
+import org.jclouds.glacier.predicates.validators.DescriptionValidator;
+import org.jclouds.glacier.predicates.validators.PayloadValidator;
 import org.jclouds.glacier.predicates.validators.VaultNameValidator;
 import org.jclouds.glacier.reference.GlacierHeaders;
+import org.jclouds.io.Payload;
+import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.Headers;
 import org.jclouds.rest.annotations.ParamValidators;
@@ -104,4 +112,38 @@ public interface GlacierAsyncClient extends Closeable {
    @Path("/-/vaults")
    @ResponseParser(ParseVaultMetadataListFromHttpContent.class)
    ListenableFuture<PaginatedVaultCollection> listVaults();
+
+   /**
+    * @see GlacierClient#uploadArchive
+    */
+   @Named("UploadArchive")
+   @POST
+   @Path("/-/vaults/{vault}/archives")
+   @ResponseParser(ParseArchiveIdHeader.class)
+   ListenableFuture<String> uploadArchive(
+         @PathParam("vault") String vaultName,
+         @ParamValidators(PayloadValidator.class) @BinderParam(BindHashesToHeaders.class) Payload payload,
+         @ParamValidators(DescriptionValidator.class) @BinderParam(BindDescriptionToHeaders.class) String description);
+
+   /**
+    * @see GlacierClient#uploadArchive
+    */
+   @Named("UploadArchive")
+   @POST
+   @Path("/-/vaults/{vault}/archives")
+   @ResponseParser(ParseArchiveIdHeader.class)
+   ListenableFuture<String> uploadArchive(
+         @PathParam("vault") String vaultName,
+         @ParamValidators(PayloadValidator.class) @BinderParam(BindHashesToHeaders.class) Payload payload);
+
+   /**
+    * @see GlacierClient#deleteArchive
+    */
+   @Named("DeleteArchive")
+   @DELETE
+   @Path("/-/vaults/{vault}/archives/{archive}")
+   ListenableFuture<Boolean> deleteArchive(
+         @PathParam("vault") String vaultName,
+         @PathParam("archive") String archiveId);
+
 }

--- a/glacier/src/main/java/org/jclouds/glacier/GlacierClient.java
+++ b/glacier/src/main/java/org/jclouds/glacier/GlacierClient.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import org.jclouds.glacier.domain.PaginatedVaultCollection;
 import org.jclouds.glacier.domain.VaultMetadata;
 import org.jclouds.glacier.options.PaginationOptions;
+import org.jclouds.io.Payload;
 
 /**
  * Provides access to Amazon Glacier resources via their REST API.
@@ -78,4 +79,37 @@ public interface GlacierClient extends Closeable {
     * @see GlacierClient#listVaults(PaginationOptions)
     */
    PaginatedVaultCollection listVaults();
+
+   /**
+    * Stores an archive in a vault.
+    *
+    * @param vaultName
+    *           Name of the Vault where the archive is being stored.
+    * @param payload
+    *           Payload to be uploaded.
+    * @param description
+    *           Description for the archive.
+    * @return A String containing the Archive identifier in Amazon Glacier.
+    * @see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html" />
+    */
+   String uploadArchive(String vaultName, Payload payload, String description);
+
+   /**
+    * Stores an archive in a vault.
+    *
+    * @see GlacierClient#uploadArchive
+    */
+   String uploadArchive(String vaultName, Payload payload);
+
+   /**
+    * Deletes an archive from a vault.
+    *
+    * @param vaultName
+    *           Name of the Vault where the archive is stored.
+    * @param archiveId
+    *           Amazon Glacier archive identifier.
+    * @return False if the archive was not deleted, true otherwise.
+    * @see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-delete.html" />
+    */
+   boolean deleteArchive(String vaultName, String archiveId);
 }

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindDescriptionToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindDescriptionToHeaders.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.binders;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.jclouds.glacier.reference.GlacierHeaders;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.rest.Binder;
+
+/**
+ * Binds the archive description to the request headers.
+ *
+ */
+public class BindDescriptionToHeaders implements Binder {
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Object input) {
+      checkNotNull(request, "request");
+      if (input == null)
+         return request;
+      checkArgument(input instanceof String, "This binder is only valid for string");
+      String description = String.class.cast(input);
+      return (R) request.toBuilder().replaceHeader(GlacierHeaders.ARCHIVE_DESCRIPTION, description).build();
+   }
+
+}

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindHashesToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindHashesToHeaders.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.binders;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+
+import org.jclouds.glacier.reference.GlacierHeaders;
+import org.jclouds.glacier.util.TreeHash;
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.io.Payload;
+import org.jclouds.rest.Binder;
+
+/**
+ * Binds the linear hash and the tree hash of payload to the request headers.
+ *
+ */
+public class BindHashesToHeaders implements Binder {
+
+   private HttpRequest addChecksumHeaders(HttpRequest request, Payload payload) {
+      try {
+         TreeHash hash = TreeHash.Hasher.buildTreeHashFromPayload(payload);
+         request = request.toBuilder()
+               .addHeader(GlacierHeaders.LINEAR_HASH, hash.getLinearHash().toString())
+               .addHeader(GlacierHeaders.TREE_HASH, hash.getTreeHash().toString())
+               .build();
+      } catch (IOException e) {
+         throw new HttpException("Error hashing the payload", e);
+      }
+      return request;
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public <R extends HttpRequest> R bindToRequest(R request, Object input) {
+      checkArgument(checkNotNull(input, "input") instanceof Payload, "This binder is only valid for Payload");
+      checkNotNull(request, "request");
+      Payload payload = Payload.class.cast(input);
+      return (R) addChecksumHeaders(request, payload);
+   }
+
+}

--- a/glacier/src/main/java/org/jclouds/glacier/functions/ParseArchiveIdHeader.java
+++ b/glacier/src/main/java/org/jclouds/glacier/functions/ParseArchiveIdHeader.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foimport org.jclouds.http.HttpException;
+import org.jclouds.http.HttpResponse;
+
+import com.google.common.base.Function;
+ for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.functions;
+
+import org.jclouds.glacier.reference.GlacierHeaders;
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpResponse;
+
+import com.google.common.base.Function;
+
+/**
+ * Parses the archiveId from the HttpResponse.
+ *
+ */
+public class ParseArchiveIdHeader implements Function<HttpResponse, String> {
+
+   @Override
+   public String apply(HttpResponse from) {
+      String id = from.getFirstHeaderOrNull(GlacierHeaders.ARCHIVE_ID);
+      if (id == null)
+         throw new HttpException("Did not receive ArchiveId");
+      return id;
+   }
+}

--- a/glacier/src/main/java/org/jclouds/glacier/predicates/validators/DescriptionValidator.java
+++ b/glacier/src/main/java/org/jclouds/glacier/predicates/validators/DescriptionValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.predicates.validators;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import org.jclouds.predicates.Validator;
+
+import com.google.common.base.CharMatcher;
+import com.google.inject.Singleton;
+
+/**
+ * Validates the archive description string.
+ */
+@Singleton
+public final class DescriptionValidator extends Validator<String> {
+
+   private static final int MAX_DESC_LENGTH = 1024;
+
+   @Override
+   public void validate(String description) {
+      if (isNullOrEmpty(description))
+         return;
+      if (description.length() > MAX_DESC_LENGTH)
+         throw exception("Description can't be longer than " + MAX_DESC_LENGTH + " characters" + " but was " + description.length());
+      CharMatcher range = getDescriptionAcceptableRange();
+      if (!range.matchesAllOf(description))
+         throw exception("Description should have ASCII values between 32 and 126.");
+   }
+
+   private static CharMatcher getDescriptionAcceptableRange() {
+      return CharMatcher.inRange(' ', '~');
+   }
+
+   protected static IllegalArgumentException exception(String reason) {
+      return new IllegalArgumentException(
+            String.format(
+                  "Description doesn't match Glacier archive description rules. "
+                        + "Reason: %s. For more info, please refer to http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html.",
+                  reason));
+   }
+}

--- a/glacier/src/main/java/org/jclouds/glacier/predicates/validators/PayloadValidator.java
+++ b/glacier/src/main/java/org/jclouds/glacier/predicates/validators/PayloadValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.predicates.validators;
+
+import org.jclouds.io.Payload;
+import org.jclouds.predicates.Validator;
+
+import com.google.inject.Singleton;
+
+/**
+ * Validates the Glacier archive payload being uploaded.
+ */
+@Singleton
+public final class PayloadValidator extends Validator<Payload> {
+
+   private static final long MAX_CONTENT_SIZE = 1L << 32; // 4GiB
+
+   @Override
+   public void validate(Payload payload) {
+      if (payload == null)
+         throw exception(payload, "Archive must have a payload.");
+      if (payload.getContentMetadata().getContentLength() == null)
+         throw exception(payload, "Content length must be set.");
+      if (payload.getContentMetadata().getContentLength() > MAX_CONTENT_SIZE)
+         throw exception(payload, "Max content size is 4gb" + " but was " + payload.getContentMetadata().getContentLength());
+   }
+
+   protected static IllegalArgumentException exception(Payload payload, String reason) {
+      return new IllegalArgumentException(
+            String.format(
+                  "Payload '%s' doesn't match Glacier archive upload rules. "
+                        + "Reason: %s. For more info, please refer to http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html.",
+                  payload, reason));
+   }
+}

--- a/glacier/src/main/java/org/jclouds/glacier/reference/GlacierHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/reference/GlacierHeaders.java
@@ -25,6 +25,10 @@ public final class GlacierHeaders {
    public static final String HEADER_PREFIX = "x-" + DEFAULT_AMAZON_HEADERTAG + "-";
    public static final String VERSION = HEADER_PREFIX + "glacier-version";
    public static final String ALTERNATE_DATE = HEADER_PREFIX + "date";
+   public static final String ARCHIVE_DESCRIPTION = HEADER_PREFIX + "archive-description";
+   public static final String LINEAR_HASH = HEADER_PREFIX + "content-sha256";
+   public static final String TREE_HASH = HEADER_PREFIX + "sha256-tree-hash";
+   public static final String ARCHIVE_ID = HEADER_PREFIX + "archive-id";
 
    private GlacierHeaders() {
    }

--- a/glacier/src/test/java/org/jclouds/glacier/predicates/validators/DescriptionValidatorTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/predicates/validators/DescriptionValidatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.predicates.validators;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.jclouds.glacier.util.TestUtils.buildData;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "DescriptionValidatorTest")
+public class DescriptionValidatorTest {
+
+   private static final DescriptionValidator VALIDATOR = new DescriptionValidator();
+
+   public void testValidate() throws IOException {
+      VALIDATOR.validate("This is a valid description");
+      VALIDATOR.validate("This_is*A#valid@Description");
+      VALIDATOR.validate("This~Is~A~Valid~Description");
+      VALIDATOR.validate("&Valid$Description");
+      VALIDATOR.validate("");
+      VALIDATOR.validate(buildData(1024).asCharSource(UTF_8).read());
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testIllegalCharacter() {
+      VALIDATOR.validate(Character.toString((char) 31));
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testIllegalCharacter2() {
+      VALIDATOR.validate(Character.toString((char) 127));
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testDescriptionTooLong() throws IOException {
+      VALIDATOR.validate(buildData(1025).asCharSource(UTF_8).read());
+   }
+}

--- a/glacier/src/test/java/org/jclouds/glacier/predicates/validators/PayloadValidatorTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/predicates/validators/PayloadValidatorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.predicates.validators;
+
+import static org.jclouds.glacier.util.TestUtils.GiB;
+import static org.jclouds.glacier.util.TestUtils.buildPayload;
+
+import org.jclouds.io.Payload;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "PayloadValidatorTest")
+public class PayloadValidatorTest {
+
+   private static final PayloadValidator VALIDATOR = new PayloadValidator();
+
+   public void testValidate() {
+      VALIDATOR.validate(buildPayload(10));
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testNoContentLength() {
+      Payload payload = buildPayload(10);
+      payload.getContentMetadata().setContentLength(null);
+      VALIDATOR.validate(payload);
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testNullPayload() {
+      VALIDATOR.validate(null);
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testContentLengthTooBig() {
+      VALIDATOR.validate(buildPayload(5 * GiB));
+   }
+
+}

--- a/glacier/src/test/java/org/jclouds/glacier/util/TestUtils.java
+++ b/glacier/src/test/java/org/jclouds/glacier/util/TestUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.util;
+
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+
+import java.util.Arrays;
+
+import org.jclouds.io.ByteSources;
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.ByteSourcePayload;
+
+import com.google.common.io.ByteSource;
+
+public class TestUtils {
+   public static final long MiB = 1L << 20;
+   public static final long GiB = 1L << 30;
+   public static final long TiB = 1L << 40;
+
+   public static Payload buildPayload(long size) {
+      ByteSource data = buildData(size);
+      Payload payload = new ByteSourcePayload(data);
+      payload.getContentMetadata().setContentType(PLAIN_TEXT_UTF_8.toString());
+      payload.getContentMetadata().setContentLength(size);
+      return payload;
+   }
+
+   public static ByteSource buildData(long size) {
+      byte[] array = new byte[1024];
+      Arrays.fill(array, (byte) 'a');
+      return ByteSources.repeatingArrayByteSource(array).slice(0, size);
+   }
+}


### PR DESCRIPTION
Now the Glacier client supports upload and delete archive
operations.

An static TestUtils class has been made for the archive operations
tests. This class allows us to build payloads and build ByteSources.
TreeHash has been refactored too to use this class instead of private
methods.

The VaultNameValidator has been refactored to use buildData when
testing big names. This makes the code more readable.
