### PR TITLE
JCLOUDS-457: Part of the code has been cleaned up

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/predicates/validators/VaultNameValidator.java
+++ b/glacier/src/main/java/org/jclouds/glacier/predicates/validators/VaultNameValidator.java
@@ -29,7 +29,7 @@ import com.google.inject.Singleton;
  * @see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-put.html" />
  */
 @Singleton
-public class VaultNameValidator extends Validator<String> {
+public final class VaultNameValidator extends Validator<String> {
 
    private static final int MIN_LENGTH = 1;
    private static final int MAX_LENGTH = 255;

--- a/glacier/src/main/java/org/jclouds/glacier/reference/GlacierHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/reference/GlacierHeaders.java
@@ -23,6 +23,7 @@ public final class GlacierHeaders {
 
    public static final String DEFAULT_AMAZON_HEADERTAG = "amz";
    public static final String HEADER_PREFIX = "x-" + DEFAULT_AMAZON_HEADERTAG + "-";
+   public static final String REQUEST_ID = HEADER_PREFIX + "RequestId";
    public static final String VERSION = HEADER_PREFIX + "glacier-version";
    public static final String ALTERNATE_DATE = HEADER_PREFIX + "date";
    public static final String ARCHIVE_DESCRIPTION = HEADER_PREFIX + "archive-description";

--- a/glacier/src/main/java/org/jclouds/glacier/util/AWSRequestSignerV4.java
+++ b/glacier/src/main/java/org/jclouds/glacier/util/AWSRequestSignerV4.java
@@ -51,7 +51,7 @@ import com.google.common.net.HttpHeaders;
  *
  * @see <a href="http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html" />
  */
-public class AWSRequestSignerV4 {
+public final class AWSRequestSignerV4 {
 
    public static final String AUTH_TAG = "AWS4";
    public static final String HEADER_TAG = "x-amz-";

--- a/glacier/src/main/java/org/jclouds/glacier/util/TreeHash.java
+++ b/glacier/src/main/java/org/jclouds/glacier/util/TreeHash.java
@@ -37,7 +37,7 @@ import com.google.common.hash.HashingInputStream;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 
-public class TreeHash {
+public final class TreeHash {
    private final HashCode treeHash;
    private final HashCode linearHash;
 

--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
@@ -41,6 +41,7 @@ import org.jclouds.glacier.reference.GlacierHeaders;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HttpHeaders;
 import com.google.inject.Module;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
@@ -70,9 +71,9 @@ public class GlacierClientMockTest {
       // Prepare the response
       MockResponse mr = new MockResponse();
       mr.setResponseCode(201);
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:02:00 GMT");
-      mr.addHeader("Location", "/111122223333/vaults/" + VAULT_NAME);
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:02:00 GMT");
+      mr.addHeader(HttpHeaders.LOCATION, "/111122223333/vaults/" + VAULT_NAME);
       MockWebServer server = new MockWebServer();
       server.enqueue(mr);
       server.play();
@@ -93,8 +94,8 @@ public class GlacierClientMockTest {
       // Prepare the response
       MockResponse mr = new MockResponse();
       mr.setResponseCode(204);
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:02:00 GMT");
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:02:00 GMT");
       MockWebServer server = new MockWebServer();
       server.enqueue(mr);
       server.play();
@@ -114,10 +115,10 @@ public class GlacierClientMockTest {
       // Prepare the response
       MockResponse mr = new MockResponse();
       mr.setResponseCode(200);
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:02:00 GMT");
-      mr.addHeader("Content-Type", "application/json");
-      mr.addHeader("Content-Length", "260");
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:02:00 GMT");
+      mr.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+      mr.addHeader(HttpHeaders.CONTENT_LENGTH, "260");
       mr.setBody("{\"CreationDate\" : \"2012-02-20T17:01:45.198Z\",\"LastInventoryDate\" : "
             + "\"2012-03-20T17:03:43.221Z\",\"NumberOfArchives\" : 192,\"SizeInBytes\" : 78088912,\"VaultARN\" : "
             + "\"arn:aws:glacier:us-east-1:012345678901:vaults/examplevault\",\"VaultName\" : \"examplevault\"}");
@@ -144,10 +145,10 @@ public class GlacierClientMockTest {
       // Prepare the response
       MockResponse mr = new MockResponse();
       mr.setResponseCode(200);
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:02:00 GMT");
-      mr.addHeader("Content-Type", "application/json");
-      mr.addHeader("Content-Length", "497");
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:02:00 GMT");
+      mr.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+      mr.addHeader(HttpHeaders.CONTENT_LENGTH, "497");
       mr.setBody("{" + "\"Marker\": null,\"VaultList\": [ {\"CreationDate\": \"2012-03-16T22:22:47.214Z\","
             + "\"LastInventoryDate\": \"2012-03-21T22:06:51.218Z\",\"NumberOfArchives\": 2,"
             + "\"SizeInBytes\": 12334,\"VaultARN\": \"arn:aws:glacier:us-east-1:012345678901:vaults/examplevault1\","
@@ -181,10 +182,10 @@ public class GlacierClientMockTest {
       // Prepare the response
       MockResponse mr = new MockResponse();
       mr.setResponseCode(200);
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:02:00 GMT");
-      mr.addHeader("Content-Type", "application/json");
-      mr.addHeader("Content-Length", "497");
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:02:00 GMT");
+      mr.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+      mr.addHeader(HttpHeaders.CONTENT_LENGTH, "497");
       mr.setBody("{\"Marker\": \"arn:aws:glacier:us-east-1:012345678901:vaults/examplevault3\","
             + "\"VaultList\": [{\"CreationDate\": \"2012-03-16T22:22:47.214Z\",\"LastInventoryDate\":"
             + "\"2012-03-21T22:06:51.218Z\",\"NumberOfArchives\": 2,\"SizeInBytes\": 12334,"
@@ -220,11 +221,11 @@ public class GlacierClientMockTest {
       MockResponse mr = new MockResponse();
       mr.setResponseCode(201);
       String responseId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyUsuhPAdTqLHy8pTl5nfCFJmDl2yEZONi5L26Omw12vcs01MNGntHEQL8MBfGlqrEXAMPLEArchiveId";
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:00:00 GMT");
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:00:00 GMT");
       mr.addHeader(GlacierHeaders.TREE_HASH, "beb0fe31a1c7ca8c6c04d574ea906e3f97b31fdca7571defb5b44dca89b5af60");
       mr.addHeader(
-            "Location",
+            HttpHeaders.LOCATION,
             "/111122223333/vaults/examplevault/archives/NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyUsuhPAdTqLHy8pTl5nfCFJmDl2yEZONi5L26Omw12vcs01MNGntHEQL8MBfGlqrEXAMPLEArchiveId");
       mr.addHeader(GlacierHeaders.ARCHIVE_ID, responseId);
       MockWebServer server = new MockWebServer();
@@ -250,8 +251,8 @@ public class GlacierClientMockTest {
       // Prepare the response
       MockResponse mr = new MockResponse();
       mr.setResponseCode(204);
-      mr.addHeader("x-amzn-RequestId", "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
-      mr.addHeader("Date", "Sun, 25 Mar 2012 12:00:00 GMT");
+      mr.addHeader(GlacierHeaders.REQUEST_ID, "AAABZpJrTyioDC_HsOmHae8EZp_uBSJr6cnGOLKp_XJCl-Q");
+      mr.addHeader(HttpHeaders.DATE, "Sun, 25 Mar 2012 12:00:00 GMT");
       MockWebServer server = new MockWebServer();
       server.enqueue(mr);
       server.play();

--- a/glacier/src/test/java/org/jclouds/glacier/predicates/validators/VaultNameValidatorTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/predicates/validators/VaultNameValidatorTest.java
@@ -16,6 +16,11 @@
  */
 package org.jclouds.glacier.predicates.validators;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.jclouds.glacier.util.TestUtils.buildData;
+
+import java.io.IOException;
+
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "VaultNameValidatorTest")
@@ -23,12 +28,13 @@ public class VaultNameValidatorTest {
 
    private static final VaultNameValidator VALIDATOR = new VaultNameValidator();
 
-   public void testValidate() {
+   public void testValidate() throws IOException {
       VALIDATOR.validate("VALID_NAME");
       VALIDATOR.validate("VALID-NAME");
       VALIDATOR.validate("VALID255NAME");
       VALIDATOR.validate("255VALID-NAME");
       VALIDATOR.validate("VALID.NAME");
+      VALIDATOR.validate(buildData(255).asCharSource(UTF_8).read());
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)
@@ -47,9 +53,7 @@ public class VaultNameValidatorTest {
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)
-   public void testNameTooLong() {
-      VALIDATOR.validate("INVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVAL" +
-            "IDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEI" +
-            "NVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAMEINVALIDNAME");
+   public void testNameTooLong() throws IOException {
+      VALIDATOR.validate(buildData(256).asCharSource(UTF_8).read());
    }
 }

--- a/glacier/src/test/java/org/jclouds/glacier/util/TreeHashTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/util/TreeHashTest.java
@@ -16,28 +16,25 @@
  */
 package org.jclouds.glacier.util;
 
+import static org.jclouds.glacier.util.TestUtils.MiB;
+import static org.jclouds.glacier.util.TestUtils.buildData;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Map;
 
-import org.jclouds.io.ByteSources;
 import org.jclouds.io.payloads.ByteSourcePayload;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.hash.HashCode;
-import com.google.common.io.ByteSource;
 
 @Test(groups = "unit", testName = "TreeHasherTest")
 public class TreeHashTest {
 
-   private static final int MB = 1024 * 1024;
-
    @Test
    public void testTreeHasherWith1MBPayload() throws IOException {
-      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(getData(1 * MB)));
+      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(buildData(1 * MiB)));
       assertEquals(th.getLinearHash(),
             HashCode.fromString("9bc1b2a288b26af7257a36277ae3816a7d4f16e89c1e7e77d0a5c48bad62b360"));
       assertEquals(th.getTreeHash(),
@@ -46,7 +43,7 @@ public class TreeHashTest {
 
    @Test
    public void testTreeHasherWith2MBPayload() throws IOException {
-      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(getData(2 * MB)));
+      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(buildData(2 * MiB)));
       assertEquals(th.getLinearHash(),
             HashCode.fromString("5256ec18f11624025905d057d6befb03d77b243511ac5f77ed5e0221ce6d84b5"));
       assertEquals(th.getTreeHash(),
@@ -55,7 +52,7 @@ public class TreeHashTest {
 
    @Test
    public void testTreeHasherWith3MBPayload() throws IOException {
-      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(getData(3 * MB)));
+      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(buildData(3 * MiB)));
       assertEquals(th.getLinearHash(),
             HashCode.fromString("6f850bc94ae6f7de14297c01616c36d712d22864497b28a63b81d776b035e656"));
       assertEquals(th.getTreeHash(),
@@ -64,7 +61,7 @@ public class TreeHashTest {
 
    @Test
    public void testTreeHasherWithMoreThan3MBPayload() throws IOException {
-      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(getData(3 * MB + 512 * 1024)));
+      TreeHash th = TreeHash.Hasher.buildTreeHashFromPayload(new ByteSourcePayload(buildData(3 * MiB + 512 * 1024)));
       assertEquals(th.getLinearHash(),
             HashCode.fromString("34c8bdd269f89a091cf17d5d23503940e0abf61c4b6544e42854b9af437f31bb"));
       assertEquals(th.getTreeHash(),
@@ -73,16 +70,10 @@ public class TreeHashTest {
 
    @Test
    public void testBuildTreeHashFromMap() throws IOException {
-      Map<Integer, HashCode> map = Maps.newTreeMap();
+      Builder<Integer, HashCode> map = ImmutableMap.<Integer, HashCode>builder();
       map.put(2, HashCode.fromString("9bc1b2a288b26af7257a36277ae3816a7d4f16e89c1e7e77d0a5c48bad62b360"));
       map.put(1, HashCode.fromString("9bc1b2a288b26af7257a36277ae3816a7d4f16e89c1e7e77d0a5c48bad62b360"));
-      HashCode treehash = TreeHash.Hasher.buildTreeHashFromMap(map);
+      HashCode treehash = TreeHash.Hasher.buildTreeHashFromMap(map.build());
       assertEquals(treehash, HashCode.fromString("560c2c9333c719cb00cfdffee3ba293db17f58743cdd1f7e4055373ae6300afa"));
-   }
-
-   private ByteSource getData(int size) {
-      byte[] array = new byte[1024];
-      Arrays.fill(array, (byte) 'a');
-      return ByteSources.repeatingArrayByteSource(array).slice(0, size);
    }
 }


### PR DESCRIPTION
On the last commit we added TestUtils class. On this commit
the VaultNameValidator and the ThreeHashTest tests make use
of it.

GlacierClientMockTest was not using GlacierHeaders references.
This commit fixes this problem too.

In addition, the AWSRequestSignerV4, the TreeHash and the
VaultNameValidator classes are now final.
