### PR TITLE
Mock server body limit moved

### DIFF
--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
@@ -119,7 +119,6 @@ public class GlacierClientMockTest {
    @BeforeMethod
    private void initServer() throws IOException {
       server = new MockWebServer();
-      server.setBodyLimit(0);
       server.play();
       client = getGlacierClient(server.getUrl("/"));
    }
@@ -256,6 +255,8 @@ public class GlacierClientMockTest {
    // TODO: Change size to 4096 when moving to JDK 7
    @Test
    public void testUploadPartMaxSize() throws InterruptedException {
+      //This forces the server to discard the request body
+      server.setBodyLimit(0);
       MockResponse mr = buildBaseResponse(204);
       mr.addHeader(GlacierHeaders.TREE_HASH, TREEHASH);
       server.enqueue(mr);


### PR DESCRIPTION
For each test, we were forcing the server to discard
the content of the request body on @BeforeMethod. We
need to do this on tests with a huge body, but it may
interfere with other tests which actually use the body data.
To fix this problem, we moved the body limit restriction to
the tests that require it.
