### PR TITLE
JCLOUDS-457: Cleanup for binder classes

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindArchiveSizeToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindArchiveSizeToHeaders.java
@@ -30,7 +30,7 @@ public class BindArchiveSizeToHeaders implements Binder {
    @SuppressWarnings("unchecked")
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
-      checkArgument(checkNotNull(input, "input") instanceof Long, "This binder is only valid for long");
+      checkArgument(input instanceof Long, "This binder is only valid for long");
       checkNotNull(request, "request");
       Long archiveSizeInMB = Long.class.cast(input);
       return (R) request.toBuilder()

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindContentRangeToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindContentRangeToHeaders.java
@@ -32,7 +32,7 @@ public class BindContentRangeToHeaders implements Binder {
    @SuppressWarnings("unchecked")
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
-      checkArgument(checkNotNull(input, "input") instanceof ContentRange, "This binder is only valid for Payload");
+      checkArgument(input instanceof ContentRange, "This binder is only valid for Payload");
       checkNotNull(request, "request");
       ContentRange range = ContentRange.class.cast(input);
       return (R) request.toBuilder().addHeader(HttpHeaders.CONTENT_RANGE, range.buildHeader()).build();

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindHashesToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindHashesToHeaders.java
@@ -49,7 +49,7 @@ public class BindHashesToHeaders implements Binder {
    @SuppressWarnings("unchecked")
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
-      checkArgument(checkNotNull(input, "input") instanceof Payload, "This binder is only valid for Payload");
+      checkArgument(input instanceof Payload, "This binder is only valid for Payload");
       checkNotNull(request, "request");
       Payload payload = Payload.class.cast(input);
       return (R) addChecksumHeaders(request, payload);

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindJobRequestToJsonPayload.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindJobRequestToJsonPayload.java
@@ -32,7 +32,7 @@ public class BindJobRequestToJsonPayload implements Binder {
 
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
-      checkArgument(checkNotNull(input, "input") instanceof JobRequest,
+      checkArgument(input instanceof JobRequest,
             "This binder is only valid for JobRequest");
       checkNotNull(request, "request");
       request.setPayload(json.toJson(input));

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindMultipartTreeHashToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindMultipartTreeHashToHeaders.java
@@ -35,7 +35,7 @@ public class BindMultipartTreeHashToHeaders implements Binder {
    @SuppressWarnings("unchecked")
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
-      checkArgument(checkNotNull(input, "input") instanceof Map, "This binder is only valid for Map");
+      checkArgument(input instanceof Map, "This binder is only valid for Map");
       checkNotNull(request, "request");
       Map<Integer, HashCode> map = Map.class.cast(input);
       checkArgument(map.size() != 0, "The map cannot be empty");

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindPartSizeToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindPartSizeToHeaders.java
@@ -30,7 +30,7 @@ public class BindPartSizeToHeaders implements Binder {
    @SuppressWarnings("unchecked")
    @Override
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
-      checkArgument(checkNotNull(input, "input") instanceof Long, "This binder is only valid for long");
+      checkArgument(input instanceof Long, "This binder is only valid for long");
       checkNotNull(request, "request");
       Long partSizeInMB = Long.class.cast(input);
       return (R) request.toBuilder()


### PR DESCRIPTION
The binder classes were making unnecessary checks. They have
been cleaned up.
