### PR TITLE
JCLOUDS-457: Multiple fixes

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/domain/PaginatedVaultCollection.java
+++ b/glacier/src/main/java/org/jclouds/glacier/domain/PaginatedVaultCollection.java
@@ -16,6 +16,8 @@
  */
 package org.jclouds.glacier.domain;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.beans.ConstructorProperties;
 import java.util.Iterator;
 
@@ -37,7 +39,7 @@ public class PaginatedVaultCollection extends IterableWithMarker<VaultMetadata> 
 
    @ConstructorProperties({ "VaultList", "Marker" })
    public PaginatedVaultCollection(Iterable<VaultMetadata> vaults, String marker) {
-      this.vaults = vaults;
+      this.vaults = checkNotNull(vaults, "vaults");
       this.marker = marker;
    }
 

--- a/glacier/src/main/java/org/jclouds/glacier/domain/VaultMetadata.java
+++ b/glacier/src/main/java/org/jclouds/glacier/domain/VaultMetadata.java
@@ -51,7 +51,7 @@ public class VaultMetadata implements Comparable<VaultMetadata> {
          long numberOfArchives, long sizeInBytes) {
       this.vaultName = checkNotNull(vaultName, "vaultName");
       this.vaultARN = checkNotNull(vaultARN, "vaultARN");
-      this.creationDate = checkNotNull(creationDate, "creationDate");
+      this.creationDate = (Date) checkNotNull(creationDate, "creationDate").clone();
       this.lastInventoryDate = lastInventoryDate;
       this.numberOfArchives = numberOfArchives;
       this.sizeInBytes = sizeInBytes;
@@ -66,7 +66,7 @@ public class VaultMetadata implements Comparable<VaultMetadata> {
    }
 
    public Date getCreationDate() {
-      return creationDate;
+      return (Date) creationDate.clone();
    }
 
    public Date getLastInventoryDate() {

--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
@@ -186,6 +186,17 @@ public class GlacierClientMockTest {
    }
 
    @Test
+   public void testListVaultsWithEmptyList() throws InterruptedException, IOException {
+      MockResponse mr = buildBaseResponse(200);
+      mr.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8);
+      mr.setBody(getResponseBody("/json/listVaultsWithEmptyListResponseBody.json"));
+      mr.addHeader(HttpHeaders.CONTENT_LENGTH, mr.getBody().length);
+      server.enqueue(mr);
+
+      assertTrue(client.listVaults().isEmpty());
+   }
+
+   @Test
    public void testListVaultsWithQueryParams() throws InterruptedException, IOException {
       MockResponse mr = buildBaseResponse(200);
       mr.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8);

--- a/glacier/src/test/resources/json/listVaultsWithEmptyListResponseBody.json
+++ b/glacier/src/test/resources/json/listVaultsWithEmptyListResponseBody.json
@@ -1,0 +1,4 @@
+{
+  "Marker": null,
+  "VaultList": []
+}


### PR DESCRIPTION
This commit addresses some problems found in the code:
- Now VaultMetadata returns a copy of the creation date instead
  of their own instance.
- Added a checkNotNull for PaginatedVaultCollection iterable.
- Added a test for listVaults with an empty list of vaults.
