### PR TITLE
Use assertj fluent assertions where appropriate

### DIFF
--- a/glacier/pom.xml
+++ b/glacier/pom.xml
@@ -89,6 +89,12 @@
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.6.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientLiveTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientLiveTest.java
@@ -16,9 +16,9 @@
  */
 package org.jclouds.glacier;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.glacier.util.TestUtils.MiB;
 import static org.jclouds.glacier.util.TestUtils.buildPayload;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -65,21 +65,23 @@ public class GlacierClientLiveTest extends BaseApiLiveTest<GlacierClient>{
       String path = api.createVault(VAULT_NAME1).toString();
       api.createVault(VAULT_NAME2);
       api.createVault(VAULT_NAME3);
-      assertTrue(path.contains("https://glacier.us-east-1.amazonaws.com/"));
-      assertTrue(path.contains("/vaults/" + VAULT_NAME1));
+      assertThat(path)
+            .contains("https://glacier.us-east-1.amazonaws.com/")
+            .contains("/vaults/" + VAULT_NAME1);
    }
 
    @Test(groups = { "integration", "live" }, dependsOnMethods = { "testCreateVault" })
    public void testListAndDescribeVaults() throws Exception {
       PaginatedVaultCollection vaults = api.listVaults();
-      assertTrue(vaults.contains(api.describeVault(VAULT_NAME1)));
-      assertTrue(vaults.contains(api.describeVault(VAULT_NAME2)));
-      assertTrue(vaults.contains(api.describeVault(VAULT_NAME3)));
+      assertThat(vaults).containsAll(ImmutableList.of(
+            api.describeVault(VAULT_NAME1),
+            api.describeVault(VAULT_NAME2),
+            api.describeVault(VAULT_NAME3)));
    }
 
    @Test(groups = { "integration", "live" }, dependsOnMethods = { "testCreateVault" })
    public void testListMultipartUploadsWithEmptyList() throws Exception {
-      assertEquals(api.listMultipartUploads(VAULT_NAME1).size(), 0);
+      assertThat(api.listMultipartUploads(VAULT_NAME1)).hasSize(0);
    }
 
    @Test(groups = { "integration", "live" }, dependsOnMethods = { "testListMultipartUploadsWithEmptyList" })
@@ -104,7 +106,7 @@ public class GlacierClientLiveTest extends BaseApiLiveTest<GlacierClient>{
          for (MultipartUploadMetadata upload : uploads) {
             list.add(upload.getMultipartUploadId());
          }
-         assertTrue(list.build().contains(uploadId));
+         assertThat(list.build()).contains(uploadId);
          assertTrue(api.abortMultipartUpload(VAULT_NAME1, uploadId));
       } finally {
          api.abortMultipartUpload(VAULT_NAME1, uploadId);

--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
@@ -18,6 +18,7 @@ package org.jclouds.glacier;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
 import static org.jclouds.Constants.PROPERTY_SO_TIMEOUT;
 import static org.jclouds.glacier.util.TestUtils.MiB;
@@ -195,7 +196,7 @@ public class GlacierClientMockTest {
       mr.addHeader(HttpHeaders.CONTENT_LENGTH, mr.getBody().length);
       server.enqueue(mr);
 
-      assertTrue(client.listVaults().isEmpty());
+      assertThat(client.listVaults()).isEmpty();
    }
 
    @Test
@@ -379,7 +380,7 @@ public class GlacierClientMockTest {
       mr.addHeader(HttpHeaders.CONTENT_LENGTH, mr.getBody().length);
       server.enqueue(mr);
 
-      assertEquals(client.listMultipartUploads(VAULT_NAME, PaginationOptions.Builder.limit(1).marker(MARKER)).size(), 0);
+      assertThat(client.listMultipartUploads(VAULT_NAME, PaginationOptions.Builder.limit(1).marker(MARKER))).isEmpty();
       assertEquals(server.takeRequest().getRequestLine(),
             "GET /-/vaults/examplevault/multipart-uploads?limit=1&marker=" + MARKER + " " + HTTP);
    }


### PR DESCRIPTION
This commit demonstrates a few instances where assertj yields more
informative error messages than testng assertEquals and assertTrue.
Note that we could replace all testng asserts with assertj.
