### PR TITLE
Default value for aws identity/credential property

### DIFF
--- a/aws-elb/pom.xml
+++ b/aws-elb/pom.xml
@@ -33,8 +33,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.aws-elb.endpoint>https://elasticloadbalancing.us-east-1.amazonaws.com</test.aws-elb.endpoint>
     <test.aws-elb.api-version>2012-06-01</test.aws-elb.api-version>
     <test.aws-elb.build-version />

--- a/aws-iam/pom.xml
+++ b/aws-iam/pom.xml
@@ -33,8 +33,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.aws-iam.endpoint>https://iam.amazonaws.com</test.aws-iam.endpoint>
     <test.aws-iam.api-version>2010-05-08</test.aws-iam.api-version>
     <test.aws-iam.build-version />

--- a/aws-rds/pom.xml
+++ b/aws-rds/pom.xml
@@ -33,8 +33,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.aws-rds.endpoint>https://rds.us-east-1.amazonaws.com</test.aws-rds.endpoint>
     <test.aws-rds.api-version>2012-04-23</test.aws-rds.api-version>
     <test.aws-rds.build-version />

--- a/elb/pom.xml
+++ b/elb/pom.xml
@@ -33,8 +33,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.elb.endpoint>https://elasticloadbalancing.us-east-1.amazonaws.com</test.elb.endpoint>
     <test.elb.api-version>2012-06-01</test.elb.api-version>
     <test.elb.build-version />

--- a/glacier/pom.xml
+++ b/glacier/pom.xml
@@ -32,8 +32,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.glacier.endpoint>https://glacier.us-east-1.amazonaws.com</test.glacier.endpoint>
     <test.glacier.api-version>2012-06-01</test.glacier.api-version>
     <test.glacier.build-version />

--- a/iam/pom.xml
+++ b/iam/pom.xml
@@ -33,8 +33,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.iam.endpoint>https://iam.amazonaws.com</test.iam.endpoint>
     <test.iam.api-version>2010-05-08</test.iam.api-version>
     <test.iam.build-version />

--- a/rds/pom.xml
+++ b/rds/pom.xml
@@ -33,8 +33,8 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <test.aws.identity>FIXME</test.aws.identity>
-    <test.aws.credential>FIXME</test.aws.credential>
+    <test.aws.identity>FIXME_IDENTITY</test.aws.identity>
+    <test.aws.credential>FIXME_CREDENTIAL</test.aws.credential>
     <test.rds.endpoint>https://rds.us-east-1.amazonaws.com</test.rds.endpoint>
     <test.rds.api-version>2012-04-23</test.rds.api-version>
     <test.rds.build-version />


### PR DESCRIPTION
Every project was using undefined properties in their pom.xml.
A default value for test.aws.identity and test.aws.credential was
added.
