### PR TITLE
JCLOUDS-457: Fix complete MPU archive size

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/GlacierAsyncClient.java
+++ b/glacier/src/main/java/org/jclouds/glacier/GlacierAsyncClient.java
@@ -218,7 +218,7 @@ public interface GlacierAsyncClient extends Closeable {
          @ParamValidators(VaultNameValidator.class) @PathParam("vault") String vaultName,
          @PathParam("uploadId") String uploadId,
          @BinderParam(BindMultipartTreeHashToHeaders.class) Map<Integer, HashCode> hashes,
-         @BinderParam(BindArchiveSizeToHeaders.class) long archiveSizeInMB);
+         @BinderParam(BindArchiveSizeToHeaders.class) long archiveSize);
 
    /**
     * @see GlacierClient#abortMultipartUpload

--- a/glacier/src/main/java/org/jclouds/glacier/GlacierClient.java
+++ b/glacier/src/main/java/org/jclouds/glacier/GlacierClient.java
@@ -168,12 +168,12 @@ public interface GlacierClient extends Closeable {
     *           Multipart upload identifier.
     * @param hashes
     *           Map containing the pairs partnumber-treehash of each uploaded part.
-    * @param archiveSizeInMB
+    * @param archiveSize
     *           Size of the complete archive.
     * @return A String containing the Archive identifier in Amazon Glacier.
     * @see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-complete-upload.html" />
     */
-   String completeMultipartUpload(String vaultName, String uploadId, Map<Integer, HashCode> hashes, long archiveSizeInMB);
+   String completeMultipartUpload(String vaultName, String uploadId, Map<Integer, HashCode> hashes, long archiveSize);
 
    /**
     * Aborts the multipart upload.

--- a/glacier/src/main/java/org/jclouds/glacier/binders/BindArchiveSizeToHeaders.java
+++ b/glacier/src/main/java/org/jclouds/glacier/binders/BindArchiveSizeToHeaders.java
@@ -32,9 +32,9 @@ public class BindArchiveSizeToHeaders implements Binder {
    public <R extends HttpRequest> R bindToRequest(R request, Object input) {
       checkArgument(input instanceof Long, "This binder is only valid for long");
       checkNotNull(request, "request");
-      Long archiveSizeInMB = Long.class.cast(input);
+      Long archiveSize = Long.class.cast(input);
       return (R) request.toBuilder()
-            .replaceHeader(GlacierHeaders.ARCHIVE_SIZE, Long.toString(archiveSizeInMB << 20))
+            .replaceHeader(GlacierHeaders.ARCHIVE_SIZE, Long.toString(archiveSize))
             .build();
    }
 

--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
@@ -310,7 +310,7 @@ public class GlacierClientMockTest {
             2, partHashcode,
             3, partHashcode,
             4, partHashcode);
-      assertThat(client.completeMultipartUpload(VAULT_NAME, MULTIPART_UPLOAD_ID, map, 8L)).isEqualTo(ARCHIVE_ID);
+      assertThat(client.completeMultipartUpload(VAULT_NAME, MULTIPART_UPLOAD_ID, map, 8 * MiB)).isEqualTo(ARCHIVE_ID);
 
       RecordedRequest request = server.takeRequest();
       assertEquals(request.getRequestLine(),


### PR DESCRIPTION
The completeMultipartUpload operation is taking the archive size
parameter in MB but it should be bytes.
