### PR TITLE
JCLOUDS-457: Add polling strategy

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/GlacierBlobStore.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/GlacierBlobStore.java
@@ -37,6 +37,7 @@ import org.jclouds.domain.Location;
 import org.jclouds.glacier.GlacierClient;
 import org.jclouds.glacier.blobstore.functions.PaginatedVaultCollectionToStorageMetadata;
 import org.jclouds.glacier.blobstore.strategy.MultipartUploadStrategy;
+import org.jclouds.glacier.blobstore.strategy.PollingStrategy;
 import org.jclouds.javax.annotation.Nullable;
 
 import com.google.common.base.Supplier;
@@ -47,13 +48,17 @@ public class GlacierBlobStore extends BaseBlobStore {
    private final GlacierClient sync;
    private final Crypto crypto;
    private final Provider<MultipartUploadStrategy> multipartUploadStrategy;
+   private final Provider<PollingStrategy> pollingStrategy;
    private final PaginatedVaultCollectionToStorageMetadata vaultsToContainers;
 
    @Inject
    GlacierBlobStore(BlobStoreContext context, BlobUtils blobUtils, Supplier<Location> defaultLocation,
                     @Memoized Supplier<Set<? extends Location>> locations, GlacierClient sync, Crypto crypto,
-                    Provider<MultipartUploadStrategy> multipartUploadStrategy, PaginatedVaultCollectionToStorageMetadata vaultsToContainers) {
+                    Provider<MultipartUploadStrategy> multipartUploadStrategy,
+                    Provider<PollingStrategy> pollingStrategy,
+                    PaginatedVaultCollectionToStorageMetadata vaultsToContainers) {
       super(context, blobUtils, defaultLocation, locations);
+      this.pollingStrategy = checkNotNull(pollingStrategy, "pollingStrategy");
       this.vaultsToContainers = checkNotNull(vaultsToContainers, "vaultsToContainers");
       this.multipartUploadStrategy = checkNotNull(multipartUploadStrategy, "multipartUploadStrategy");
       this.sync = checkNotNull(sync, "sync");

--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/config/GlacierBlobStoreContextModule.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/config/GlacierBlobStoreContextModule.java
@@ -24,7 +24,9 @@ import org.jclouds.glacier.blobstore.GlacierAsyncBlobStore;
 import org.jclouds.glacier.blobstore.GlacierBlobStore;
 import org.jclouds.glacier.blobstore.strategy.ClearVaultStrategy;
 import org.jclouds.glacier.blobstore.strategy.MultipartUploadStrategy;
+import org.jclouds.glacier.blobstore.strategy.PollingStrategy;
 import org.jclouds.glacier.blobstore.strategy.SlicingStrategy;
+import org.jclouds.glacier.blobstore.strategy.internal.BasePollingStrategy;
 import org.jclouds.glacier.blobstore.strategy.internal.BaseSlicingStrategy;
 import org.jclouds.glacier.blobstore.strategy.internal.SequentialMultipartUploadStrategy;
 
@@ -39,5 +41,6 @@ public class GlacierBlobStoreContextModule extends AbstractModule {
       bind(MultipartUploadStrategy.class).to(SequentialMultipartUploadStrategy.class);
       bind(SlicingStrategy.class).to(BaseSlicingStrategy.class);
       bind(ClearListStrategy.class).to(ClearVaultStrategy.class);
+      bind(PollingStrategy.class).to(BasePollingStrategy.class);
    }
 }

--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/PollingStrategy.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/PollingStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.blobstore.strategy;
+
+public interface PollingStrategy {
+   boolean waitForSuccess(String vault, String job) throws InterruptedException;
+}

--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/internal/BasePollingStrategy.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/internal/BasePollingStrategy.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.glacier.blobstore.strategy.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jclouds.glacier.GlacierClient;
+import org.jclouds.glacier.blobstore.strategy.PollingStrategy;
+import org.jclouds.glacier.domain.JobMetadata;
+import org.jclouds.glacier.domain.JobStatus;
+
+import com.google.inject.Inject;
+
+public class BasePollingStrategy implements PollingStrategy {
+   public static final long DEFAULT_INITIAL_WAIT = TimeUnit.HOURS.toMillis(3);
+   public static final long DEFAULT_TIME_BETWEEN_POLLS = TimeUnit.MINUTES.toMillis(15);
+
+   private final GlacierClient client;
+   private final long initialWait;
+   private final long timeBetweenPolls;
+
+   public BasePollingStrategy(long initialWait, long timeBetweenPolls, GlacierClient client) {
+      this.initialWait = initialWait;
+      this.timeBetweenPolls = timeBetweenPolls;
+      this.client = checkNotNull(client, "client");
+   }
+
+   @Inject
+   public BasePollingStrategy(GlacierClient client) {
+      this(DEFAULT_INITIAL_WAIT, DEFAULT_TIME_BETWEEN_POLLS, client);
+   }
+
+   private boolean inProgress(String job, String vault) {
+      JobMetadata jobMetadata = client.describeJob(vault, job);
+      return (jobMetadata != null) && (jobMetadata.getStatusCode() == JobStatus.IN_PROGRESS);
+   }
+
+   private void waitForJob(String job, String vault) throws InterruptedException {
+      Thread.sleep(initialWait);
+      while (inProgress(job, vault)) {
+         Thread.sleep(timeBetweenPolls);
+      }
+   }
+
+   private boolean succeeded(String job, String vault) {
+      JobMetadata jobMetadata = client.describeJob(vault, job);
+      return (jobMetadata != null) && (jobMetadata.getStatusCode() == JobStatus.SUCCEEDED);
+   }
+
+   @Override
+   public boolean waitForSuccess(String vault, String job) throws InterruptedException {
+      // Avoid waiting if the job doesn't exist
+      if (client.describeJob(vault, job) == null) {
+         return false;
+      }
+      waitForJob(job, vault);
+      return succeeded(job, vault);
+   }
+
+}


### PR DESCRIPTION
The polling strategy interface for job operations
and a simple implementation class have been added.
This implementation waits an initial time and then
polls at regular intervals.
