### PR TITLE
JCLOUDS-457: Fix deleteContainer

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/GlacierBlobStore.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/GlacierBlobStore.java
@@ -92,7 +92,7 @@ public class GlacierBlobStore extends BaseBlobStore {
 
    @Override
    public void deleteContainer(String container) {
-      if(!sync.deleteVault(container)) {
+      if (!sync.deleteVault(container)) {
          deletePathAndEnsureGone(container);
       }
    }

--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/ClearVaultStrategy.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/ClearVaultStrategy.java
@@ -46,7 +46,7 @@ public class ClearVaultStrategy implements ClearListStrategy {
       try {
          if (pollingStrategy.waitForSuccess(container, jobId)) {
             ArchiveMetadataCollection archives = sync.getInventoryRetrievalOutput(container, jobId);
-            for(ArchiveMetadata archive : archives) {
+            for (ArchiveMetadata archive : archives) {
                try {
                   sync.deleteArchive(container, archive.getArchiveId());
                } catch (ResourceNotFoundException ignored) {


### PR DESCRIPTION
The ClearVaultStrategy now ignores ResourceNotFound exceptions.

deleteContainer now tries to delete the vault first to avoid long waits.
If the delete request fails, retries it every 24 hours.
