### PR TITLE
Revert "Fix poms so that modernizer doesn't fail on snapshot."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,20 +64,6 @@
     </repository>
   </repositories>
 
-  <!-- For modernizer, which depends on jclouds-resources snapshot. -->
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache-snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <modules>
     <module>elb</module>
     <module>iam</module>


### PR DESCRIPTION
This reverts commit 70a3a4f86c82bf2e7b112de1599062141b46b120. The
snapshot repository has now been added to the jclouds-project POM.

See jclouds/jclouds@79d4b48
