### PR TITLE
Use AutoService for creation of Service Loader Metadata

### DIFF
--- a/aws-elb/pom.xml
+++ b/aws-elb/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/aws-elb/src/main/java/org/jclouds/aws/elb/AWSELBProviderMetadata.java
+++ b/aws-elb/src/main/java/org/jclouds/aws/elb/AWSELBProviderMetadata.java
@@ -35,10 +35,12 @@ import org.jclouds.elb.ELBApiMetadata;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of @ link org.jclouds.types.ProviderMetadata} for Amazon's Elastic Load Balancing
- * provider.
+ * Implementation of {@link ProviderMetadata} for Amazon's Elastic Load Balancing provider.
  */
+@AutoService(ProviderMetadata.class)
 public class AWSELBProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {
@@ -49,7 +51,7 @@ public class AWSELBProviderMetadata extends BaseProviderMetadata {
    public Builder toBuilder() {
       return Builder.class.cast(builder().fromProviderMetadata(this));
    }
-   
+
    public AWSELBProviderMetadata() {
       super(builder());
    }
@@ -68,7 +70,7 @@ public class AWSELBProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_2 + ".endpoint",
             "https://elasticloadbalancing.us-west-2.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + SA_EAST_1 + ".endpoint",
-            "https://elasticloadbalancing.sa-east-1.amazonaws.com");      
+            "https://elasticloadbalancing.sa-east-1.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + EU_WEST_1 + ".endpoint",
             "https://elasticloadbalancing.eu-west-1.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + AP_SOUTHEAST_1 + ".endpoint",
@@ -80,7 +82,7 @@ public class AWSELBProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(PROPERTY_ZONECLIENT_ENDPOINT, "https://ec2.us-east-1.amazonaws.com");
       return properties;
    }
-   
+
    public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder(){

--- a/aws-elb/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/aws-elb/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.aws.elb.AWSELBProviderMetadata

--- a/aws-iam/pom.xml
+++ b/aws-iam/pom.xml
@@ -75,6 +75,11 @@
       <version>${jclouds.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/aws-iam/src/main/java/org/jclouds/aws/iam/AWSIAMProviderMetadata.java
+++ b/aws-iam/src/main/java/org/jclouds/aws/iam/AWSIAMProviderMetadata.java
@@ -23,11 +23,12 @@ import org.jclouds.iam.IAMApiMetadata;
 import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of @ link org.jclouds.types.ProviderMetadata} for Amazon's IAM
- * provider.
-*
-*/
+ * Implementation of {@link ProviderMetadata} for Amazon's IAM provider.
+ */
+@AutoService(ProviderMetadata.class)
 public class AWSIAMProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {
@@ -38,7 +39,7 @@ public class AWSIAMProviderMetadata extends BaseProviderMetadata {
    public Builder toBuilder() {
       return builder().fromProviderMetadata(this);
    }
-   
+
    public AWSIAMProviderMetadata() {
       super(builder());
    }
@@ -51,7 +52,7 @@ public class AWSIAMProviderMetadata extends BaseProviderMetadata {
       Properties properties = new Properties();
       return properties;
    }
-   
+
    public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder(){
@@ -70,7 +71,7 @@ public class AWSIAMProviderMetadata extends BaseProviderMetadata {
       public AWSIAMProviderMetadata build() {
          return new AWSIAMProviderMetadata(this);
       }
-      
+
       @Override
       public Builder fromProviderMetadata(ProviderMetadata in) {
          super.fromProviderMetadata(in);

--- a/aws-iam/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/aws-iam/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.aws.iam.AWSIAMProviderMetadata

--- a/aws-rds/pom.xml
+++ b/aws-rds/pom.xml
@@ -80,6 +80,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/aws-rds/src/main/java/org/jclouds/aws/rds/AWSRDSProviderMetadata.java
+++ b/aws-rds/src/main/java/org/jclouds/aws/rds/AWSRDSProviderMetadata.java
@@ -35,10 +35,12 @@ import org.jclouds.providers.ProviderMetadata;
 import org.jclouds.providers.internal.BaseProviderMetadata;
 import org.jclouds.rds.RDSApiMetadata;
 
+import com.google.auto.service.AutoService;
+
 /**
- * Implementation of @ link org.jclouds.types.ProviderMetadata} for Amazon's Elastic Load Balancing
- * provider.
+ * Implementation of {@link ProviderMetadata} for Amazon's Elastic Load Balancing provider.
  */
+@AutoService(ProviderMetadata.class)
 public class AWSRDSProviderMetadata extends BaseProviderMetadata {
 
    public static Builder builder() {
@@ -49,7 +51,7 @@ public class AWSRDSProviderMetadata extends BaseProviderMetadata {
    public Builder toBuilder() {
       return Builder.class.cast(builder().fromProviderMetadata(this));
    }
-   
+
    public AWSRDSProviderMetadata() {
       super(builder());
    }
@@ -68,7 +70,7 @@ public class AWSRDSProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_2 + ".endpoint",
             "https://rds.us-west-2.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + SA_EAST_1 + ".endpoint",
-            "https://rds.sa-east-1.amazonaws.com");      
+            "https://rds.sa-east-1.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + EU_WEST_1 + ".endpoint",
             "https://rds.eu-west-1.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + AP_SOUTHEAST_1 + ".endpoint",
@@ -80,7 +82,7 @@ public class AWSRDSProviderMetadata extends BaseProviderMetadata {
       properties.setProperty(PROPERTY_ZONECLIENT_ENDPOINT, "https://ec2.us-east-1.amazonaws.com");
       return properties;
    }
-   
+
    public static class Builder extends BaseProviderMetadata.Builder {
 
       protected Builder(){

--- a/aws-rds/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
+++ b/aws-rds/src/main/resources/META-INF/services/org.jclouds.providers.ProviderMetadata
@@ -1,1 +1,0 @@
-org.jclouds.aws.rds.AWSRDSProviderMetadata

--- a/elb/pom.xml
+++ b/elb/pom.xml
@@ -112,6 +112,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/elb/src/main/java/org/jclouds/elb/ELBApiMetadata.java
+++ b/elb/src/main/java/org/jclouds/elb/ELBApiMetadata.java
@@ -22,17 +22,20 @@ import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.apis.ApiMetadata;
 import org.jclouds.elb.config.ELBHttpApiModule;
 import org.jclouds.elb.loadbalancer.config.ELBLoadBalancerContextModule;
 import org.jclouds.loadbalancer.LoadBalancerServiceContext;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
  * Implementation of {@link ApiMetadata} for Amazon's Elastic Load Balancing api.
  */
+@AutoService(ApiMetadata.class)
 public class ELBApiMetadata extends BaseHttpApiMetadata<ELBApi> {
 
    @Override
@@ -47,14 +50,14 @@ public class ELBApiMetadata extends BaseHttpApiMetadata<ELBApi> {
    protected ELBApiMetadata(Builder builder) {
       super(Builder.class.cast(builder));
    }
-   
+
    public static Properties defaultProperties() {
       Properties properties = BaseHttpApiMetadata.defaultProperties();
       properties.setProperty(PROPERTY_AUTH_TAG, "AWS");
       properties.setProperty(PROPERTY_HEADER_TAG, "amz");
       return properties;
    }
-   
+
    public static class Builder extends BaseHttpApiMetadata.Builder<ELBApi, Builder> {
 
       protected Builder() {

--- a/elb/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/elb/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.elb.ELBApiMetadata

--- a/glacier/pom.xml
+++ b/glacier/pom.xml
@@ -121,6 +121,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/glacier/src/main/java/org/jclouds/glacier/GlacierApiMetadata.java
+++ b/glacier/src/main/java/org/jclouds/glacier/GlacierApiMetadata.java
@@ -22,6 +22,7 @@ import static org.jclouds.reflect.Reflection2.typeToken;
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.apis.ApiMetadata;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.glacier.blobstore.config.GlacierBlobStoreContextModule;
 import org.jclouds.glacier.config.GlacierHttpApiModule;
@@ -29,12 +30,14 @@ import org.jclouds.glacier.config.GlacierParserModule;
 import org.jclouds.glacier.reference.GlacierHeaders;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
  * Implementation of ApiMetadata for Amazon Glacier API
  */
+@AutoService(ApiMetadata.class)
 public class GlacierApiMetadata extends BaseHttpApiMetadata {
 
    private static Builder builder() {

--- a/glacier/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/glacier/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.glacier.GlacierApiMetadata

--- a/iam/pom.xml
+++ b/iam/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/iam/src/main/java/org/jclouds/iam/IAMApiMetadata.java
+++ b/iam/src/main/java/org/jclouds/iam/IAMApiMetadata.java
@@ -22,12 +22,16 @@ import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.apis.ApiMetadata;
 import org.jclouds.iam.config.IAMHttpApiModule;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
+
+import com.google.auto.service.AutoService;
 
 /**
  * Implementation of {@link ApiMetadata} for Amazon's IAM api.
  */
+@AutoService(ApiMetadata.class)
 public class IAMApiMetadata extends BaseHttpApiMetadata<IAMApi> {
 
    @Override

--- a/iam/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/iam/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.iam.IAMApiMetadata

--- a/rds/pom.xml
+++ b/rds/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/rds/src/main/java/org/jclouds/rds/RDSApiMetadata.java
+++ b/rds/src/main/java/org/jclouds/rds/RDSApiMetadata.java
@@ -22,15 +22,18 @@ import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import java.net.URI;
 import java.util.Properties;
 
+import org.jclouds.apis.ApiMetadata;
 import org.jclouds.rds.config.RDSHttpApiModule;
 import org.jclouds.rest.internal.BaseHttpApiMetadata;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Module;
 
 /**
  * Implementation of {@link ApiMetadata} for Amazon's Relational Database Service api.
  */
+@AutoService(ApiMetadata.class)
 public class RDSApiMetadata extends BaseHttpApiMetadata<RDSApi> {
 
    @Override
@@ -45,14 +48,14 @@ public class RDSApiMetadata extends BaseHttpApiMetadata<RDSApi> {
    protected RDSApiMetadata(Builder builder) {
       super(Builder.class.cast(builder));
    }
-   
+
    public static Properties defaultProperties() {
       Properties properties = BaseHttpApiMetadata.defaultProperties();
       properties.setProperty(PROPERTY_AUTH_TAG, "AWS");
       properties.setProperty(PROPERTY_HEADER_TAG, "amz");
       return properties;
    }
-   
+
    public static class Builder extends BaseHttpApiMetadata.Builder<RDSApi, Builder> {
 
       protected Builder() {

--- a/rds/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
+++ b/rds/src/main/resources/META-INF/services/org.jclouds.apis.ApiMetadata
@@ -1,1 +1,0 @@
-org.jclouds.rds.RDSApiMetadata


### PR DESCRIPTION
This PR updates all of the apis/providers to use AutoService and fixes several failed tests.