### PR TITLE
Patches to be able to use the Glacier Proxy

### DIFF
--- a/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/internal/BasePollingStrategy.java
+++ b/glacier/src/main/java/org/jclouds/glacier/blobstore/strategy/internal/BasePollingStrategy.java
@@ -48,7 +48,8 @@ public class BasePollingStrategy implements PollingStrategy {
 
    @Inject
    public BasePollingStrategy(GlacierClient client) {
-      this(client, DEFAULT_INITIAL_WAIT, DEFAULT_TIME_BETWEEN_POLLS);
+      this(client, Long.parseLong(System.getProperty("test.glacier.initial-wait",
+              Long.toString(DEFAULT_INITIAL_WAIT))), DEFAULT_TIME_BETWEEN_POLLS);
    }
 
    private boolean inProgress(String job, String vault) {

--- a/glacier/src/test/java/org/jclouds/glacier/GlacierClientLiveTest.java
+++ b/glacier/src/test/java/org/jclouds/glacier/GlacierClientLiveTest.java
@@ -56,11 +56,9 @@ public class GlacierClientLiveTest extends BaseApiLiveTest<GlacierClient> {
 
    @Test
    public void testCreateVault() throws Exception {
-      assertThat(api.createVault(VAULT_NAME1).toString())
-            .contains("https://glacier.us-east-1.amazonaws.com/")
-            .contains("/vaults/" + VAULT_NAME1);
-      api.createVault(VAULT_NAME2);
-      api.createVault(VAULT_NAME3);
+      assertThat(api.createVault(VAULT_NAME1).toString()).contains("/vaults/" + VAULT_NAME1);
+      assertThat(api.createVault(VAULT_NAME2).toString()).contains("/vaults/" + VAULT_NAME2);
+      assertThat(api.createVault(VAULT_NAME3).toString()).contains("/vaults/" + VAULT_NAME3);
    }
 
    @Test(dependsOnMethods = {"testCreateVault"})


### PR DESCRIPTION
I'm working on a Glacier proxy/emulator and jclouds seems like a good use case for it (so that one could more quickly run the integration tests, for example). There two changes that I've had to make:
1. the tests shouldn't assume an AWS endpoint (otherwise they won't pass with glacier proxy)
2. the `initial-wait` setting -- the time to wait before checking a job completed -- is a system property

After these changes, I was able to pass all of the jclouds tests with the glacier proxy.